### PR TITLE
Fix: Item inventories now properly hydrate

### DIFF
--- a/src/Inventory.js
+++ b/src/Inventory.js
@@ -101,6 +101,7 @@ class Inventory extends Map {
       let newItem = state.ItemFactory.create(area, def.entityReference);
       newItem.uuid = uuid;
       newItem.belongsTo = belongsTo;
+      newItem.initializeInventory(def.inventory);
       newItem.hydrate(state, def);
       this.set(uuid, newItem);
       state.ItemManager.add(newItem);


### PR DESCRIPTION
Currently, when loading player inventories, any containers or other items having an inventory would not properly hydrate with their contents.  However, any player equipment having an inventory would properly hydrate.  Inventory.hydrate() now properly makes the call to Item.initializeInventory(inventory) prior to Item.hydrate() to resolve this issue.