### PR TITLE
Add ability to get the exit by the target room

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -199,6 +199,23 @@ class Room extends GameEntity {
   }
 
   /**
+   * Get the exit definition of a room's exit to a given room
+   * @param {Room} nextRoom
+   * @return {false|Object}
+   */
+  getExitToRoom(nextRoom) {
+    const exits = this.getExits();
+
+    if (!exits.length) {
+      return false;
+    }
+
+    const roomExit = exits.find(ex => ex.roomId === nextRoom.entityReference);
+
+    return roomExit || false;
+  }
+
+  /**
    * Check to see if this room has a door preventing movement from `fromRoom` to here
    * @param {Room} fromRoom
    * @return {boolean}


### PR DESCRIPTION
I'm finding a number of cases where I know the room I'm in, and the room I'm going to, or vice versa, and needing to determine the direction.

Rather than repeating a bunch of looping code, this feels like something useful within the core API.

If not, let me know and I'll just find a place to cram something similar into a bundle.