### PR TITLE
Area not defined

### DIFF
--- a/src/AreaManager.js
+++ b/src/AreaManager.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Area = require('./Area');
 const BehaviorManager = require('./BehaviorManager');
 
 /**

--- a/src/BundleManager.js
+++ b/src/BundleManager.js
@@ -503,6 +503,10 @@ class BundleManager {
       const loader = require(eventPath);
       const eventImport = this._getLoader(loader, srcPath);
 
+      if (typeof eventImport.event !== 'function') {
+        throw new Error(`Bundle ${bundle} has an invalid input event '${eventName}'. Expected a function, got: `, eventImport.event);
+      }
+
       this.state.InputEventManager.add(eventName, eventImport.event(this.state));
     }
 

--- a/src/Damage.js
+++ b/src/Damage.js
@@ -17,7 +17,7 @@ class Damage {
    */
   constructor(attribute, amount, attacker = null, source = null, metadata = {}) {
     if (!Number.isFinite(amount)) {
-      throw new TypeError("Damage amount must be a finite Number");
+      throw new TypeError(`Damage amount must be a finite Number, got ${amount}.`);
     }
 
     if (typeof attribute !== 'string') {

--- a/src/EffectFactory.js
+++ b/src/EffectFactory.js
@@ -56,6 +56,9 @@ class EffectFactory {
    */
   create(id, config = {}, state = {}) {
     const entry = this.effects.get(id);
+    if (!entry || !entry.definition) {
+      throw new Error(`No valid entry definition found for effect ${id}.`);
+    }
     let def = Object.assign({}, entry.definition);
     def.config = Object.assign(def.config, config);
     def.state = Object.assign(def.state || {}, state);


### PR DESCRIPTION
I got this error:
2019-02-07T00:57:41.222Z - error: ERROR: Player Admin was saved to invalid room limbo:white.
(node:85615) UnhandledPromiseRejectionWarning: ReferenceError: Area is not defined
    at AreaManager.getPlaceholderArea (/Users/seanohue/myProjects/core/src/AreaManager.js:72:29)
    at Player.hydrate (/Users/seanohue/myProjects/core/src/Player.js:210:34)
    at TelnetStream.<anonymous> (/Users/seanohue/myProjects/myelin-server/bundles/bundle-example-input-events/input-events/done.js:12:12)
    at TelnetStream.emit (events.js:182:13)
    at Object.onSelect (/Users/seanohue/myProjects/myelin-server/bundles/bundle-example-input-events/input-events/choose-character.js:73:20)
    at process._tickCallback (internal/process/next_tick.js:68:7)

When loading a player after deleting the limbo area.

Seems to be a simple fix.