### PR TITLE
Added warning when a command with the same name is loaded multiple times

### DIFF
--- a/src/BundleManager.js
+++ b/src/BundleManager.js
@@ -404,6 +404,11 @@ class BundleManager {
       }
 
       const commandName = path.basename(commandFile, path.extname(commandFile));
+
+      if (this.state.CommandManager.get(commandName)) {
+        Logger.warn(`Command '${commandName}' already exists and will be discarded`);
+      }
+
       const command = this.createCommand(commandPath, commandName, bundle);
       this.state.CommandManager.add(command);
     }


### PR DESCRIPTION
With this PR there will be a warning when a command with the same name will be loaded again.
There is room for improvement:

1.  should we also check aliases?
2. Please help me with the warning message I put in there. Should it be different?