### PR TITLE
Metadatable#setMeta now fires an event whenever metadata changes

### DIFF
--- a/src/Metadatable.js
+++ b/src/Metadatable.js
@@ -41,7 +41,7 @@ class extends parentClass {
 
     const oldValue = base[property];
     base[property] = value;
-    this.emit('metadataUpdated', key, oldValue, value);
+    this.emit('metadataUpdated', key, value, oldValue);
   }
 
   /**

--- a/src/Metadatable.js
+++ b/src/Metadatable.js
@@ -21,6 +21,7 @@ class extends parentClass {
    * @param {*}      value Value must be JSON.stringify-able
    * @throws Error
    * @throws RangeError
+   * @fires Metadatable#metadataUpdate
    */
   setMeta(key, value) {
     if (!this.metadata) {

--- a/src/Metadatable.js
+++ b/src/Metadatable.js
@@ -41,6 +41,13 @@ class extends parentClass {
 
     const oldValue = base[property];
     base[property] = value;
+    
+    /**
+    * @event Metadatable#metadataUpdate
+    * @param {string} key
+    * @param {*} newValue
+    * @param {*} oldValue
+    */
     this.emit('metadataUpdated', key, value, oldValue);
   }
 

--- a/src/Metadatable.js
+++ b/src/Metadatable.js
@@ -39,7 +39,9 @@ class extends parentClass {
       base = base[part];
     }
 
+    const oldValue = base[property];
     base[property] = value;
+    this.emit('metadataUpdated', key, oldValue, value);
   }
 
   /**


### PR DESCRIPTION
Addresses #66 

The only thing I was unsure about is that whenever the metadata doesn't exist, `oldVal` returns undefined, but I left as is since that could be treated as desired behavior since it's actually undefined.

And excuse the typo.