### PR TITLE
Loading A Player From an Invalid Room

### DIFF
--- a/src/AreaManager.js
+++ b/src/AreaManager.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const BehaviorManager = require('./BehaviorManager');
+const Area = require('./Area');
+const Room = require('./Room');
 
 /**
  * Stores references to, and handles distribution of, active areas


### PR DESCRIPTION
If a player is loaded from an invalid room (you can test this by just changing the Player's JSON file; under 'room'), AreaManager attempts to spin up a placeholder room and area and plop the player inside that. 

When this code ran, I received: `(node:27798) UnhandledPromiseRejectionWarning: ReferenceError: Room is not defined
    at AreaManager.getPlaceholderArea (/Users/avienneau/Projects/ranviermud/node_modules/ranvier/src/AreaManager.js:77:29)` for both ROOM and AREA in this file. After adding the appropriate requires, the player loaded fine.

You're going to want to test this yourself before merging my changes. . .