### PR TITLE
fix result of PlayerManager's getBroadcastTargets

### DIFF
--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -183,7 +183,7 @@ class PlayerManager extends EventEmitter {
    * @return {Array<Character>}
    */
   getBroadcastTargets() {
-    return this.players;
+    return this.players.values();
   }
 }
 

--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -183,7 +183,7 @@ class PlayerManager extends EventEmitter {
    * @return {Array<Character>}
    */
   getBroadcastTargets() {
-    return this.players.values();
+    return this.getPlayersAsArray();
   }
 }
 


### PR DESCRIPTION
This updates `PlayerManager.getBroadcastTargets` to return the intended array of Character objects, rather than the `players` map itself. This fixes an issue where calls like `Broadcast.sayAt(state.PlayerManager, 'message to all')` would fail silently.