### PR TITLE
Handle quests without rewards

### DIFF
--- a/src/QuestFactory.js
+++ b/src/QuestFactory.js
@@ -97,6 +97,11 @@ class QuestFactory {
       player.emit('questComplete', instance);
       player.questTracker.complete(instance.entityReference);
 
+      if (!quest.config.rewards) {
+        player.save();
+        return;
+      }
+
       for (const reward of quest.config.rewards) {
         try {
           const rewardClass = GameState.QuestRewardManager.get(reward.type);


### PR DESCRIPTION
If a quest has no rewards, the server crashes. Save and return early in that case.