### PR TITLE
Remove old code

### DIFF
--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -159,10 +159,6 @@ class PlayerManager extends EventEmitter {
   async saveAll() {
     for (const [ name, player ] of this.players.entries()) {
       await this.save(player);
-      /**
-       * @event Player#save
-       */
-      player.emit('saved', playerCallback);
     }
   }
 


### PR DESCRIPTION
The save() method already emits the saved event. The old code was emitting it again, and referencing an unknown variable playerCallback.