### PR TITLE
Actually use the account.serialize() when saving.

### DIFF
--- a/src/Account.js
+++ b/src/Account.js
@@ -86,7 +86,7 @@ class Account {
    * @param {function} callback after-save callback
    */
   save(callback) {
-    Data.save('account', this.username, this, callback);
+    Data.save('account', this.username, this.serialize(), callback);
   }
 
   /**


### PR DESCRIPTION
Probably haven't encountered any problems, but otherwise the serialize() never gets called. 

For my use case, I overrode the Account.serialize() with my data I wanted to store and it wasn't saving.