### PR TITLE
Area#removeRoomFromMap

### DIFF
--- a/src/Area.js
+++ b/src/Area.js
@@ -87,6 +87,7 @@ class Area extends GameEntity {
    * @fires Area#roomRemoved
    */
   removeRoom(room) {
+    this.removeRoomFromMap(room);
     this.rooms.delete(room.id);
 
     /**
@@ -113,6 +114,21 @@ class Area extends GameEntity {
 
     const floor = this.map.get(z);
     floor.addRoom(x, y, room);
+  }
+
+  removeRoomFromMap(room) {
+    if (!room.coordinates) {
+      throw new Error('Room does not have coordinates');
+    }
+
+    const {x, y, z} = room.coordinates;
+
+    if (!this.map.has(z)) {
+      throw new Error(`That floor doesn't exist`);
+    }
+
+    const floor = this.map.get(z);
+    floor.removeRoom(x, y);
   }
 
   /**


### PR DESCRIPTION
Currently if you Area#addRoom() it adds the room to the floor map, but you if call Area#removeRoom, it removes it from the area, but leaves it in the floor map. Resulting in bad things, like crashes when a player tries to view adjacent rooms that lookup their implied exits through the floor map. Any suggestions on how this could better?