### PR TITLE
Added walls for blocking exits when using room coordinates

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -17,6 +17,7 @@ const Logger = require('./Logger');
  * @property {string}        script       Name of custom script attached to this room
  * @property {string}        title        Title shown on look/scan
  * @property {object}        doors        Doors restricting access to this room. See documentation for format
+ * @property {object}        walls        Walls permanently restricting access from this room.
  *
  * @extends GameEntity
  */
@@ -50,6 +51,7 @@ class Room extends GameEntity {
     // create by-val copies of the doors config so the lock/unlock don't accidentally modify the original definition
     this.doors = new Map(Object.entries(JSON.parse(JSON.stringify(def.doors || {}))));
     this.defaultDoors = def.doors;
+    this.walls = def.walls || [];
 
     this.items = new Set();
     this.npcs = new Set();
@@ -175,7 +177,8 @@ class Room extends GameEntity {
         this.coordinates.z + z
       );
 
-      if (room && !exits.find(ex => ex.direction === adj.dir)) {
+      //Generate exits based on coordinates and walls
+      if (room && !exits.find(ex => ex.direction === adj.dir) && !this.hasWall(adj.dir)) {
         exits.push({ roomId: room.entityReference, direction: adj.dir, inferred: true });
       }
     }
@@ -215,6 +218,18 @@ class Room extends GameEntity {
     const roomExit = exits.find(ex => ex.roomId === nextRoom.entityReference);
 
     return roomExit || false;
+  }
+
+  /**
+   * Check to see if this room has a wall preventing movement in this direction
+   * @param {String} direciton
+   * @return {boolean}
+   */
+  hasWall(direciton) {
+    if(this.walls.find(ex => ex.direction === direciton) ){
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/src/Room.js
+++ b/src/Room.js
@@ -222,11 +222,11 @@ class Room extends GameEntity {
 
   /**
    * Check to see if this room has a wall preventing movement in this direction
-   * @param {String} direciton
+   * @param {String} direction
    * @return {boolean}
    */
-  hasWall(direciton) {
-    if(this.walls.find(ex => ex.direction === direciton) ){
+  hasWall(direction) {
+    if(this.walls.find(ex => ex.direction === direction) ){
       return true;
     }
     return false;

--- a/src/Room.js
+++ b/src/Room.js
@@ -17,7 +17,7 @@ const Logger = require('./Logger');
  * @property {string}        script       Name of custom script attached to this room
  * @property {string}        title        Title shown on look/scan
  * @property {object}        doors        Doors restricting access to this room. See documentation for format
- * @property {object}        walls        Walls permanently restricting access from this room.
+ * @property {Array<object>} walls        Walls permanently restricting access from this room { direction: string }
  *
  * @extends GameEntity
  */


### PR DESCRIPTION
**Issue:** When using rooms with coordinates all rooms get connected automatically.

**Example:** When you have the room
1 2
3 4

and you don't want the player to directly move from 1 to 3 there is no way to block the movement permanently (so it doesn't even show up in look, move etc.).

**Solution:** Adding a "walls" parameter to rooms which allows you to define a direction in which no exit will be generated. The walls won't show up in look or move unlike doors, causing less confusion and a cleaner syntax.

**YAML Syntax:**

walls Array
Walls permanently restricting access from this room. Each walls entry has the following field:

> direction string
>     required Direction which gets blocked by the wall.

