### PR TITLE
make MobManager#removeMob act on sourceRoom

### DIFF
--- a/src/MobManager.js
+++ b/src/MobManager.js
@@ -21,10 +21,14 @@ class MobManager {
    */
   removeMob(mob) {
     mob.effects.clear();
+    const sourceRoom = mob.sourceRoom;
+    if (sourceRoom) {
+      sourceRoom.area.removeNpc(mob);
+      sourceRoom.removeNpc(mob, true);
+    }
     const room = mob.room;
-    if (room) {
-      room.area.removeNpc(mob);
-      room.removeNpc(mob, true);
+    if (room && room !== sourceRoom) {
+      room.removeNpc(mob);
     }
     mob.__pruned = true;
     mob.removeAllListeners();


### PR DESCRIPTION
Most of the room-specific logic in MobManager#removeMob should act on the mob's source room (as set by Room#spawnNpc), instead of its current room. Otherwise, the mob is never removed from its source room's `spawnedNpcs` set, (and possibly the relevant Area's `npc` set) if it is removed while in any room other than its source.