### PR TITLE
Set active properties before emitting events

### DIFF
--- a/src/Effect.js
+++ b/src/Effect.js
@@ -144,29 +144,30 @@ class Effect extends EventEmitter {
     if (this.active) {
       return;
     }
-
+    
     this.startedAt = Date.now() - this.elapsed;
+    this.active = true;
+
     /**
      * @event Effect#effectActivated
      */
     this.emit('effectActivated');
-    this.active = true;
   }
 
   /**
-   * Set this effect active
+   * Set this effect inactive
    * @fires Effect#effectDeactivated
    */
   deactivate() {
     if (!this.active) {
       return;
     }
+    this.active = false;
 
     /**
      * @event Effect#effectDeactivated
      */
     this.emit('effectDeactivated');
-    this.active = false;
   }
 
   /**


### PR DESCRIPTION
This changes `Effect#activate` and `Effect#deactivate` such that the Effect's `active` property is set to the proper value before their corresponding events are emitted. Most importantly, this prevents a case where an infinite loop might be created.

Example (some debugEffect.js):

```js
module.exports = {
  config: {
    duration: 1000
  },
  listeners: state => ({
    effectDeactivated: function() {
      this.target.emit('badNews'); // infinite loop
      Broadcast.sayAt(this.target, "Effect deactivated.");
    }
  })
};
```

In this case, `EffectList#validateEffects` and the listener function will be stuck invoking one another until the stack overflows. While less likely to occur practice, we could engineer a similar loop with `Effect#activate` and its related event.

Setting the `active` property before any events are called ensures that each method will short-circuit before this becomes an issue.
