### PR TITLE
EffectFactory fixes

### DIFF
--- a/src/EffectFactory.js
+++ b/src/EffectFactory.js
@@ -39,6 +39,9 @@ class EffectFactory {
     this.effects.set(id, { definition, eventManager });
   }
 
+  /**
+   * @see Map#has
+   */
   has(id) {
     return this.effects.has(id);
   }

--- a/src/EffectFactory.js
+++ b/src/EffectFactory.js
@@ -52,7 +52,8 @@ class EffectFactory {
    * @return {object}
    */
   get(id) {
-    return this.effects.get(id);
+    const entry = this.effects.get(id);
+    if (entry) return entry.definition;
   }
 
   /**

--- a/src/EffectFactory.js
+++ b/src/EffectFactory.js
@@ -49,7 +49,7 @@ class EffectFactory {
    * @return {object}
    */
   get(id) {
-    return this.get(id);
+    return this.effects.get(id);
   }
 
   /**


### PR DESCRIPTION
This fixes an issue where a missing reference in `EffectFactory#get` would cause the method to call itself infinitely.

It also adds a docstring to `EffectFactory#has`, mirroring the one set on `AttributeFactory#has`