### PR TITLE
Allow for extendable Entity Loaders

### DIFF
--- a/src/EntityLoader.js
+++ b/src/EntityLoader.js
@@ -56,6 +56,14 @@ class EntityLoader {
 
     return this.dataSource.update(this.config, id, data);
   }
+
+  remove(id) {
+    if (!('remove' in this.dataSource)) {
+      throw new Error(`remove not supported by ${this.dataSource.name}`);
+    }
+
+    return this.dataSource.remove(this.config, id);
+  }
 }
 
 module.exports = EntityLoader;

--- a/src/EntityLoaderRegistry.js
+++ b/src/EntityLoaderRegistry.js
@@ -25,10 +25,15 @@ class EntityLoaderRegistry extends Map {
 
       const sourceConfig = settings.config || {};
 
-      this.set(name, new EntityLoader(sourceRegistry.get(settings.source), sourceConfig));
+      // use an extended loader, if one is set.
+      const loader = source._loader || EntityLoader;
+
+      this.set(
+        name,
+        new loader(sourceRegistry.get(settings.source), sourceConfig)
+      );
     }
   }
 }
 
 module.exports = EntityLoaderRegistry;
-


### PR DESCRIPTION
This implements a new, optional feature to `DataSourceRegistry` and `EntityLoaderRegistry` that allows developers to extend the behavior of the default `EntityLoader` class. It additionally addresses one component of #96 by adding a `remove` method to `EntityLoader`.

### Current Issue

`EntityLoader` defines a complete CRUD API sufficient for working with core Ranvier components, but developers may wish to make use of additional functionality provided to them by their chosen method of persistence. For example, a developer using an SQL solution may wish to query for or operate on a subset of data, which is inefficient using the provided `fetchAll` and `replace` methods, particularly on large datasets.

### Proposed Solution

Because we can't predict what features might be available to any one backend, we can instead allow developers to define extensions to `EntityLoader`. These extensions will most often be written by DataSource authors (and included alongside it) to take advantage of their loader's unique features, but can be defined independently if desired.

To enable a loader extension, we add an additional option to the `dataSources` field in `ranvier.json`:

```js
{
  "dataSources" : {
    // Path to the DataSource class, as usual.
    "require": "./loaders/mySQLDataSource",
    
    // Path to the extension function.
    "extendLoader": "./loaders/mySQLLoaderExtension"
  }
}
```

If `extendLoader` is set, `DataSourceRegistry` will call the function with `EntityLoader` to create a mixin class, which will be used for all Entity Loaders using that source. Example:

```js
// ./loaders/mySQLLoaderExtension

const loaderExtension = EntityLoader => class SQLEntityLoader extends EntityLoader {
  
  SQL(statement, ...params) {
    // Added functionality.
    // Executes a query statement and returns the result.
    return this.dataSource.SQL(/* ... */);
  }
  
  fetch(id) {
    // Extended functionality.
    // Could be used to audit/filter/transform/etc
    return super.fetch(id);
  }
}

module.exports = loaderExtension;
```