### PR TITLE
Add 'walls' property to inferred/coordinate-driven rooms

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -42,6 +42,7 @@ class Room extends GameEntity {
       y: def.coordinates[1],
       z: def.coordinates[2],
     } : null;
+    this.walls = new Set(def.walls || []);
     this.description = def.description;
     this.entityReference = this.area.name + ':' + def.id;
     this.exits = def.exits || [];
@@ -112,7 +113,7 @@ class Room extends GameEntity {
 
   /**
    * @param {Npc} npc
-   * @param {boolean} removeSpawn 
+   * @param {boolean} removeSpawn
    */
   removeNpc(npc, removeSpawn = false) {
     this.npcs.delete(npc);
@@ -142,9 +143,11 @@ class Room extends GameEntity {
    * Get exits for a room. Both inferred from coordinates and  defined in the
    * 'exits' property.
    *
+   * @param {Object} options
+   *
    * @return {Array<{ id: string, direction: string, inferred: boolean, room: Room= }>}
    */
-  getExits() {
+  getExits({ignoreWalls = false} = {}) {
     const exits = JSON.parse(JSON.stringify(this.exits)).map(exit => {
       exit.inferred = false;
       return exit;
@@ -175,7 +178,9 @@ class Room extends GameEntity {
         this.coordinates.z + z
       );
 
-      if (room && !exits.find(ex => ex.direction === adj.dir)) {
+      if (room && !exits.find(ex => ex.direction === adj.dir) &&
+        (ignoreWalls || !this.walls.has(adj.dir)))
+      {
         exits.push({ roomId: room.entityReference, direction: adj.dir, inferred: true });
       }
     }


### PR DESCRIPTION
This adds a `walls` property to rooms such that inferred/coordinate-driven rooms can be side-by-side yet still divided by a wall. Doors work as per normal.

The general template for this change was provided in Slack. So far my testing has not shown it to cause any issues or conflicts with the existing implementation.

Example usage:
```yaml
- id: foo
  title: Foo
  coordinates: [0, -1, 0]
  description: Walls!
  walls: [ "east", "southeast" ]
```