### PR TITLE
Add the effect variable to the emit that is being removed to player

### DIFF
--- a/src/EffectList.js
+++ b/src/EffectList.js
@@ -153,7 +153,7 @@ class EffectList {
     /**
      * @event Character#effectRemoved
      */
-    this.target.emit('effectRemoved');
+    this.target.emit('effectRemoved', effect);
   }
 
   /**


### PR DESCRIPTION
Don't really see a reason not to, but my use case is to listen for the 'effectRemoved' on the player and update my websocket client with that specific effect being removed. This would be the cleanest way to do it.