### PR TITLE
Fix #63 and change #54 to use an early return

### DIFF
--- a/src/Character.js
+++ b/src/Character.js
@@ -504,6 +504,10 @@ class Character extends Metadatable(EventEmitter) {
    * @fires Character#unfollowed
    */
   unfollow() {
+    if (!this.following) {
+      return
+    }
+    
     this.following.removeFollower(this);
     /**
      * @event Character#unfollowed

--- a/src/Room.js
+++ b/src/Room.js
@@ -9,7 +9,7 @@ const Logger = require('./Logger');
  * @property {Array<number>} defaultItems Default list of item ids that should load in this room
  * @property {Array<number>} defaultNpcs  Default list of npc ids that should load in this room
  * @property {string}        description  Room description seen on 'look'
- * @property {Array<object>} exits        Exits out of this room { id: number, direction: string }
+ * @property {Array<object>} exits        Exits out of this room { roomId: string, direction: string, inferred: boolean }
  * @property {number}        id           Area-relative id (vnum)
  * @property {Set}           items        Items currently in the room
  * @property {Set}           npcs         Npcs currently in the room


### PR DESCRIPTION
- Properly define `Room.exits` for documentation purposes.
- Use early return on `Character.unfollow()`