### PR TITLE
Fix #63, #54, #62, and #101

### DIFF
--- a/src/Character.js
+++ b/src/Character.js
@@ -435,14 +435,6 @@ class Character extends Metadatable(EventEmitter) {
    */
   removeItem(item) {
     this.inventory.removeItem(item);
-
-    // if we removed the last item unset the inventory
-    // This ensures that when it's reloaded it won't try to set
-    // its default inventory. Instead it will persist the fact
-    // that all the items were removed from it
-    if (!this.inventory.size) {
-      this.inventory = null;
-    }
     item.carriedBy = null;
   }
 

--- a/src/Character.js
+++ b/src/Character.js
@@ -504,6 +504,10 @@ class Character extends Metadatable(EventEmitter) {
    * @fires Character#unfollowed
    */
   unfollow() {
+    if (!this.following) {
+      return
+    }
+
     this.following.removeFollower(this);
     /**
      * @event Character#unfollowed

--- a/src/Character.js
+++ b/src/Character.js
@@ -50,8 +50,6 @@ class Character extends Metadatable(EventEmitter) {
     } else {
       this.metadata = {};
     }
-
-    this._setupInventory();
   }
 
   /**
@@ -424,6 +422,7 @@ class Character extends Metadatable(EventEmitter) {
    * @param {Item} item
    */
   addItem(item) {
+    this._setupInventory();
     this.inventory.addItem(item);
     item.carriedBy = this;
   }
@@ -458,6 +457,7 @@ class Character extends Metadatable(EventEmitter) {
    * @return {boolean}
    */
   isInventoryFull() {
+    this._setupInventory();
     return this.inventory.isFull;
   }
 

--- a/src/Character.js
+++ b/src/Character.js
@@ -50,6 +50,8 @@ class Character extends Metadatable(EventEmitter) {
     } else {
       this.metadata = {};
     }
+
+    this._setupInventory();
   }
 
   /**
@@ -422,7 +424,6 @@ class Character extends Metadatable(EventEmitter) {
    * @param {Item} item
    */
   addItem(item) {
-    this._setupInventory();
     this.inventory.addItem(item);
     item.carriedBy = this;
   }
@@ -457,7 +458,6 @@ class Character extends Metadatable(EventEmitter) {
    * @return {boolean}
    */
   isInventoryFull() {
-    this._setupInventory();
     return this.inventory.isFull;
   }
 

--- a/src/EffectList.js
+++ b/src/EffectList.js
@@ -94,6 +94,9 @@ class EffectList {
       throw new Error('Cannot add effect, already has a target.');
     }
 
+    // create deep clone of state before proceeding
+    effect.state = JSON.parse(JSON.stringify(effect.state));
+
     for (const activeEffect of this.effects) {
       if (effect.config.type === activeEffect.config.type) {
         if (activeEffect.config.maxStacks && activeEffect.state.stacks < activeEffect.config.maxStacks) {

--- a/src/Item.js
+++ b/src/Item.js
@@ -76,8 +76,6 @@ class Item extends GameEntity {
 
     this.carriedBy = null;
     this.equippedBy = null;
-
-    this._setupInventory();
   }
 
   /**

--- a/src/Item.js
+++ b/src/Item.js
@@ -76,6 +76,8 @@ class Item extends GameEntity {
 
     this.carriedBy = null;
     this.equippedBy = null;
+
+    this._setupInventory();
   }
 
   /**
@@ -100,7 +102,6 @@ class Item extends GameEntity {
    * @param {Item} item
    */
   addItem(item) {
-    this._setupInventory();
     this.inventory.addItem(item);
     item.carriedBy = this;
   }
@@ -118,7 +119,6 @@ class Item extends GameEntity {
    * @return {boolean}
    */
   isInventoryFull() {
-    this._setupInventory();
     return this.inventory.isFull;
   }
 

--- a/src/Item.js
+++ b/src/Item.js
@@ -111,14 +111,6 @@ class Item extends GameEntity {
    */
   removeItem(item) {
     this.inventory.removeItem(item);
-
-    // if we removed the last item unset the inventory
-    // This ensures that when it's reloaded it won't try to set
-    // its default inventory. Instead it will persist the fact
-    // that all the items were removed from it
-    if (!this.inventory.size) {
-      this.inventory = null;
-    }
     item.carriedBy = null;
   }
 

--- a/src/Item.js
+++ b/src/Item.js
@@ -102,6 +102,7 @@ class Item extends GameEntity {
    * @param {Item} item
    */
   addItem(item) {
+    this._setupInventory();
     this.inventory.addItem(item);
     item.carriedBy = this;
   }
@@ -119,6 +120,7 @@ class Item extends GameEntity {
    * @return {boolean}
    */
   isInventoryFull() {
+    this._setupInventory();
     return this.inventory.isFull;
   }
 

--- a/src/Npc.js
+++ b/src/Npc.js
@@ -35,7 +35,7 @@ class Npc extends Scriptable(Character) {
     this.description = data.description;
     this.entityReference = data.entityReference; 
     this.id = data.id;
-    this.keywords = data.keywords;
+    this.keywords = new Array(...data.keywords);
     this.quests = data.quests || [];
     this.uuid = data.uuid || uuid();
     this.commandQueue = new CommandQueue();

--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -154,7 +154,7 @@ class PlayerManager extends EventEmitter {
   }
 
   /**
-   * @fires Player#saved
+   * Save all players
    */
   async saveAll() {
     for (const [ name, player ] of this.players.entries()) {

--- a/src/Room.js
+++ b/src/Room.js
@@ -9,7 +9,7 @@ const Logger = require('./Logger');
  * @property {Array<number>} defaultItems Default list of item ids that should load in this room
  * @property {Array<number>} defaultNpcs  Default list of npc ids that should load in this room
  * @property {string}        description  Room description seen on 'look'
- * @property {Array<object>} exits        Exits out of this room { id: number, direction: string }
+ * @property {Array<object>} exits        Exits out of this room { roomId: string, direction: string, inferred: boolean }
  * @property {number}        id           Area-relative id (vnum)
  * @property {Set}           items        Items currently in the room
  * @property {Set}           npcs         Npcs currently in the room


### PR DESCRIPTION
- Properly define `Room.exits` for documentation purposes.
- Use early return on `Character.unfollow()`
- Create new copy of `this.keywords` when spawning a `Npc`
- Deep clone `effect.state` before adding to an entity