### PR TITLE
Allow diagonal directions to be optional

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -2,6 +2,7 @@
 
 const GameEntity = require('./GameEntity');
 const Logger = require('./Logger');
+const Config = require('./Config');
 
 /**
  * @property {Area}          area         Area room is in
@@ -154,18 +155,24 @@ class Room extends GameEntity {
       return exits;
     }
 
-    const adjacents = [
+    let adjacents = [
       { dir: 'west', coord: [-1, 0, 0] },
       { dir: 'east', coord: [1, 0, 0] },
       { dir: 'north', coord: [0, 1, 0] },
       { dir: 'south', coord: [0, -1, 0] },
       { dir: 'up', coord: [0, 0, 1] },
-      { dir: 'down', coord: [0, 0, -1] },
-      { dir: 'northeast', coord: [1, 1, 0] },
-      { dir: 'northwest', coord: [-1, 1, 0] },
-      { dir: 'southeast', coord: [1, -1, 0] },
-      { dir: 'southwest', coord: [-1, -1, 0] },
+      { dir: 'down', coord: [0, 0, -1] }
     ];
+
+    if (Config.get('diagonalDirections') === undefined || Config.get('diagonalDirections')) {
+      adjacents = [
+        ...adjacents,
+        { dir: 'northeast', coord: [1, 1, 0] },
+        { dir: 'northwest', coord: [-1, 1, 0] },
+        { dir: 'southeast', coord: [1, -1, 0] },
+        { dir: 'southwest', coord: [-1, -1, 0] }
+      ]
+    }
 
     for (const adj of adjacents) {
       const [x, y, z] = adj.coord;

--- a/src/Room.js
+++ b/src/Room.js
@@ -140,6 +140,21 @@ class Room extends GameEntity {
   }
 
   /**
+   * Check if diagonal directions are enabled
+   *
+   * @return {boolean}
+   */
+  checkDiagonalDirections() {
+    if (this.metadata.diagonalDirections !== undefined) {
+      return this.metadata.diagonalDirections;
+    }
+    if (Config.get('diagonalDirections') !== undefined) {
+      return Config.get('diagonalDirections')
+    }
+    else return true
+  }
+
+  /**
    * Get exits for a room. Both inferred from coordinates and  defined in the
    * 'exits' property.
    *
@@ -164,14 +179,14 @@ class Room extends GameEntity {
       { dir: 'down', coord: [0, 0, -1] }
     ];
 
-    if (Config.get('diagonalDirections') === undefined || Config.get('diagonalDirections')) {
+    if (this.checkDiagonalDirections()) {
       adjacents = [
         ...adjacents,
         { dir: 'northeast', coord: [1, 1, 0] },
         { dir: 'northwest', coord: [-1, 1, 0] },
         { dir: 'southeast', coord: [1, -1, 0] },
         { dir: 'southwest', coord: [-1, -1, 0] }
-      ]
+      ];
     }
 
     for (const adj of adjacents) {


### PR DESCRIPTION
This PR allows disabling diagonal directions via a `diagonalDirections` property in `ranvier.json`. The `Room#getExits` function is the only method in `core` that references diagonal directions.

I added a `Room#checkDiagonalDirections` method that allows you to check if diagonal are supported from within anywhere else in state. You can override `ranvier.json` on a per-Room basis by adding a `diagonalDirections` property to a Room's `metadata`.

Please note that bundles implementing `CommandParser`, commands like `look`, and any listener in `player-events` for `move` may have their own uses of diagonals. Those references to diagonals are isolated to bundles and not a part of `core`. However, you can use the new `Room#checkDiagonalDirections` to consistently control the use of diagonal directions in your game.

As well, this PR allows you to fully ignore diagonal directions in `core` if you so wish.

By default, not including a `diagonalDirections` property in `ranvier.json` or a Room's `metadata` will result in diagonals being enabled. This is the current default setting in Ranvier when using a coordinate system.