### PR TITLE
Event: combatantAdded missed hook

### DIFF
--- a/src/Character.js
+++ b/src/Character.js
@@ -251,6 +251,7 @@ class Character extends Metadatable(EventEmitter) {
     // this doesn't use `addCombatant` because `addCombatant` automatically
     // adds this to the target's combatants list as well
     this.combatants.add(target);
+    this.emit('combatantAdded', target);
     if (!target.isInCombat()) {
       // TODO: This hardcoded 2.5 second lag on the target needs to be refactored
       target.initiateCombat(this, 2500);


### PR DESCRIPTION
`combatantAdded` event needs to be added to the `initiateCombat()` as it is not calling `addCombatant()` directly. There is no way to find the initial target otherewise as the `combatStart` event occurs before a target is added to the combatant list.